### PR TITLE
feat(langs): skip language selection when only one language is configured

### DIFF
--- a/lua/codecompanion/_extensions/gitcommit/langs.lua
+++ b/lua/codecompanion/_extensions/gitcommit/langs.lua
@@ -17,6 +17,12 @@ function M.select_lang(callback)
     return
   end
 
+  -- If only one language is configured, use it directly
+  if #_langs == 1 then
+    callback(_langs[1])
+    return
+  end
+
   vim.ui.select(_langs, {
     prompt = "Select language:",
     format_item = function(item)


### PR DESCRIPTION
- Automatically use the single configured language without prompting
- Improves user experience by removing unnecessary selection step
- Maintains existing behavior for multiple languages or no languages